### PR TITLE
Fix debug parameter caused warning

### DIFF
--- a/api_newsplus/init.php
+++ b/api_newsplus/init.php
@@ -223,7 +223,7 @@ class Api_newsplus extends Plugin {
 				$query_strategy_part ORDER BY $order_by
 				$limit_query_part $offset_query_part";
 
-			if ($_REQUEST["debug"]) print $query;
+			if (isset($_REQUEST["debug"]) && $_REQUEST["debug"]) print $query;
 
 			$result = $this->pdo->query($query);
 


### PR DESCRIPTION
This PR will get rid of undefined index error

```
Undefined index: debug
1. plugins.local/api_newsplus/init.php(226): ttrss_error_handler(8, Undefined index: debug, plugins.local/api_newsplus/init.php, 226, [{"feed":-4,"limit":10000,"view_mode":"unread","offset":0,"since_id":0,"owner_uid":1,"ext_tables_part":"","since_id_part":"","view_query_part":" unread = true AND ","limit_query_part":"LIMIT 10000","allow_archived":true,"query_strategy_part":"true","order_b...)
2. plugins.local/api_newsplus/init.php(64): queryFeedHeadlines(-4, 10000, unread, 0, 0)
3. plugins.local/api_newsplus/init.php(52): buildHeadlinesArray(-4, 10000, 0, unread, 0)
4. classes/api.php(498): getCompactHeadlines()
5. api/index.php(57): index(getcompactheadlines)
```